### PR TITLE
Allow disabling apt repo setup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+barman_apt_custom_repo_enabled: true
 barman_apt_key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
 barman_apt_repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
 barman_package_state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,12 @@
 ---
 - name: Add Barman apt key
+  when: barman_apt_custom_repo_enabled
   ansible.builtin.apt_key:
     url: "{{ barman_apt_key_url }}"
   become: yes
 
 - name: Add Barman repository
+  when: barman_apt_custom_repo_enabled
   ansible.builtin.apt_repository:
     repo: "{{ barman_apt_repo }}"
   become: yes


### PR DESCRIPTION
This allows to install `barman` from the distribution repo when `barman_apt_custom_repo_enabled` is set to `false`